### PR TITLE
Update when supercluster options change

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,7 @@ const useSupercluster = <
     }
 
     pointsRef.current = points;
-  }, [points, bounds, zoomInt]);
+  }, [points, bounds, zoomInt, options]);
 
   return { clusters, supercluster: superclusterRef.current };
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,7 @@ const useSupercluster = <
   useDeepCompareEffectNoCheck(() => {
     if (!superclusterRef.current
       || !dequal(pointsRef.current, points)
-      || !dequal(superclusterRef.current.options, options)
+      || !dequal((superclusterRef.current as typeof superclusterRef.current & {options: typeof options}).options, options)
     ) {
       superclusterRef.current = new Supercluster(options);
       superclusterRef.current.load(points);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,7 +28,10 @@ const useSupercluster = <
   const zoomInt = Math.round(zoom);
 
   useDeepCompareEffectNoCheck(() => {
-    if (!superclusterRef.current || !dequal(pointsRef.current, points)) {
+    if (!superclusterRef.current
+      || !dequal(pointsRef.current, points)
+      || !dequal(superclusterRef.current.options, options)
+    ) {
       superclusterRef.current = new Supercluster(options);
       superclusterRef.current.load(points);
     }


### PR DESCRIPTION
I tried to implement a feature that allowed the cluster options to be changed dynamically (in my case, the radius) and noticed that my UI did not change. I found that the useEffect dependent keys did not include the supercluster options, so useSupercluster did not trigger a change.

I addressed this by creating a new supercluster instance. I am not very familiar with the supercluster library so it's possible there is a way to reuse the same instance but update its options, which could be faster.