### PR TITLE
feat: add enabled option

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ export interface UseSuperclusterArgument<P, C> {
   points: Array<Supercluster.PointFeature<P>>;
   bounds?: BBox;
   zoom: number;
-  options?: Supercluster.Options<P, C>;
+  options?: Supercluster.Options<P, C> & { enabled?: boolean };
 }
 
 const useSupercluster = <
@@ -28,6 +28,10 @@ const useSupercluster = <
   const zoomInt = Math.round(zoom);
 
   useDeepCompareEffectNoCheck(() => {
+    if (options?.enabled === false) {
+      return;
+    }
+
     if (
       !superclusterRef.current ||
       !dequal(pointsRef.current, points) ||


### PR DESCRIPTION
### What
Enabled 옵션을 전달 가능하도록 합니다.

### Why
You can address the unnecessary clustering and resulting UI changes occurring when keepPreviousData is set to true in tanstack-query. 

When keepPreviousData is true, the data returned by tanstack-query retains the previous data while requesting new data. If keepPreviousData were set to false, data would hold an undefined value.

Let's consider the following scenario

Imagine requesting data for drawing markers on a map that matches the new map information when zooming out. If keepPreviousData is set to true and a zoom-out occurs, the following steps lead to displaying newly clustered markers, but the steps have problem.

(1) Zoom-out
(2) Request for new data + Show clustered markers base on previous data adjusted to the new map information ( 😈  In this step, unnecessary clustering and UI changes may occur. )
(3) Receive new data + Display clustered markers based on the new data 

### How
We added the 'enabled' option to the Options Prop. By passing '!isFetching' to the 'enabled' option from the 'tanstack-query' returned isFetching, the issue can be resolved.

### Result
| AS-IS | TO-BE |
| :---: | :---: |
| <img width="451" alt="image" src="https://github.com/leighhalliday/use-supercluster/assets/81841082/436e26f5-807d-4a0c-aa26-4d7d18007676"> | <img width="452" alt="image" src="https://github.com/leighhalliday/use-supercluster/assets/81841082/1d0498f1-86d9-4321-b417-93e91def8792"> |