### PR TITLE
Use correct export for vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "1.1.0",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "dist/use-supercluster.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Fixes #72 

Changed as there's no `dist/index.js` after building.