### PR TITLE
doc: write about installing additional dev dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ You will need to install [Supercluster](https://github.com/mapbox/supercluster) 
 yarn add supercluster use-supercluster
 ```
 
+If you're using TypeScript, you'll also need to install the type definitions:
+
+```txt
+yarn add @types/supercluster --dev
+```
+
 ## Examples
 
 This package contains an example along with tests, but full examples with instructions in the most popular mapping libraries for React can be found below.


### PR DESCRIPTION
## Why?

Currently, the README does not provide guidance on installing type-related packages when using supercluster in a TypeScript environment.

I have added the relevant information to address this.
https://github.com/mapbox/supercluster?tab=readme-ov-file#typescript